### PR TITLE
Update Jumoo.TranslationManager.OpenAi.csproj

### DIFF
--- a/Jumoo.TranslationManager.OpenAi.csproj
+++ b/Jumoo.TranslationManager.OpenAi.csproj
@@ -44,7 +44,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
+		<PackageReference Include="Azure.AI.OpenAI" Version="2.1.0-beta.2" />
 		<PackageReference Include="Betalgo.Ranul.OpenAI" Version="9.0.1" />
 	</ItemGroup>
 


### PR DESCRIPTION
Currently, Jumoo.TranslationManager.OpenAi depends on Azure.AI.OpenAI (>= 2.1.0), while Semantic Kernel (1.34.0 and similar) references Azure.AI.OpenAI (2.1.0-beta.2). Since only one version of the SDK can be loaded at runtime, this causes NU1107 version conflicts and prevents projects from using Translation Manager together with Semantic Kernel.